### PR TITLE
Disable hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sudo -E `which nix` --extra-experimental-features 'nix-command flakes' run -vL g
 Build with
 
 ```sh
-nice -n 19 ionice -c 3 nix build .#nixosConfigurations.nixluon.config.system.build.toplevel
+nice -n 19 ionice -c 3 nix build .#nixosConfigurations.$(hostname).config.system.build.toplevel
 ```
 
 Update with

--- a/home/viluon/home.nix
+++ b/home/viluon/home.nix
@@ -312,7 +312,7 @@ in
   };
 
   wayland.windowManager.hyprland = {
-    enable = true;
+    enable = false;
     settings = {
       # Monitor configuration
       monitor = [

--- a/hosts/nixboerse/default.nix
+++ b/hosts/nixboerse/default.nix
@@ -109,6 +109,8 @@
 
   services.ddccontrol.enable = true;
 
+  programs.wireshark.enable = true;
+
   programs.chromium = {
     enable = true;
     extensions =

--- a/hosts/nixboerse/default.nix
+++ b/hosts/nixboerse/default.nix
@@ -53,20 +53,36 @@
   virtualisation.libvirtd = {
     enable = true;
     qemu.package = pkgs.qemu_kvm;
-    hooks.qemu = {
-      libvirtd-network-hook = pkgs.writeShellScript "libvirtd-network-hook" ''
-        set -euo pipefail
+    hooks.qemu =
+      let
+        domains = builtins.concatStringsSep " " [
+          "cedelgroup.com"
+          "cloudconsole-pa.clients6.google.com"
+          "cloudusersettings-pa.clients6.google.com"
+          "dbgcloud.io"
+          "deutsche-boerse.de"
+          "gke.goog"
+          "googleapis.com"
+          "oa.pnrad.net"
+        ];
 
-        case $1:$2 in
-          ubuntu:start)
-            ${pkgs.systemd}/bin/resolvectl dns virbr0 100.64.0.2
-            ${pkgs.systemd}/bin/resolvectl domain virbr0 deutsche-boerse.de oa.pnrad.net dbgcloud.io googleapis.com gke.goog cloudusersettings-pa.clients6.google.com cloudconsole-pa.clients6.google.com
-            ${pkgs.systemd}/bin/resolvectl default-route virbr0 no
-            ${pkgs.systemd}/bin/resolvectl dnsovertls virbr0 no
-            ;;
-        esac
-      '';
-    };
+        resolvectl = "${pkgs.systemd}/bin/resolvectl";
+        VM = "ubuntu";
+      in
+      {
+        libvirtd-network-hook = pkgs.writeShellScript "libvirtd-network-hook" ''
+          set -euo pipefail
+
+          case $1:$2 in
+            ${VM}:start)
+              ${resolvectl} dns virbr0 100.64.0.2
+              ${resolvectl} domain virbr0 ${domains}
+              ${resolvectl} default-route virbr0 no
+              ${resolvectl} dnsovertls virbr0 no
+              ;;
+          esac
+        '';
+      };
   };
 
   systemd.services.libvirtd.restartTriggers = [

--- a/modules/users/common.nix
+++ b/modules/users/common.nix
@@ -15,6 +15,7 @@
       "networkmanager"
       "uinput"
       "wheel"
+      "wireshark"
       config.hardware.i2c.group
     ];
     packages = [


### PR DESCRIPTION
Apparently the home-manager module is buggy (and/or badly misconfigured here).
It messes up GTK dark mode and introduces its own
`org.freedesktop.impl.portal.desktop.hyprland` which conflicts with
`org.freedesktop.impl.portal.desktop.gnome`, breaking screen sharing in GNOME.